### PR TITLE
Updates MEDSDM to ingest DC2 data

### DIFF
--- a/medsdm/defaults.py
+++ b/medsdm/defaults.py
@@ -10,7 +10,7 @@ object
 DEFAULT_MAKER_CONFIG = {
     # need this for lsst
     #'refband':'i',
-    
+
     # types of cutout images to make. Note psf is
     # automatically made
     'cutout_types': ['image','weight','seg','bmask'],
@@ -28,7 +28,9 @@ DEFAULT_MAKER_CONFIG = {
     'variable_psf_box_size': True,
 }
 
+# Camera options are: LSST, HSC
 DEFAULT_PRODUCER_CONFIG = {
+    'camera':'LSST',
     'fake_seg_radius':5,
     'min_box_size':32,
     'max_box_size':256,
@@ -37,5 +39,3 @@ DEFAULT_PRODUCER_CONFIG = {
     'include_epochs':True,
     'deblend_coadd':False,
 }
-
-

--- a/medsdm/producer.py
+++ b/medsdm/producer.py
@@ -44,9 +44,9 @@ class LSSTProducer(object):
 
         # NOTE: this is a fix to work under the main LSST obs_lsstSim,
         # this is fixed in the DESC fork and the butler can directly be used
-        self.coadd_image_id = self._computeCoaddExposureId(self, dataId, True)
+        self.coadd_image_id = self._computeCoaddExposureId(dataId, True)
         #self.coadd_image_id = butler.get("deepCoaddId", dataId)
-        
+
         self.ref = butler.get(
             "deepCoadd_ref",
             tract=tract, patch=patch,

--- a/medsdm/producer.py
+++ b/medsdm/producer.py
@@ -15,6 +15,7 @@ import types
 import lsst.daf.persistence as dafPersist
 import lsst.afw.geom as afwGeom
 import lsst.afw.image as afwImage
+import lsst.afw.image.utils as afwImageUtils
 import lsst.afw.table as afwTable
 import lsst.afw.geom.ellipses as afwEllipses
 


### PR DESCRIPTION
A few minor fixes were necessary, in particular the `obs_lsstSims` package in the default LSST stack is outdated and doesn't work with the skymap used in DC2. There is a fix in the DESC fork of that package, but I just directly included the necessary code here so that this can run on a normal DM stack.
Also fixed the `dataId` to access specific visit level CCDs and updated the name of the `slot_PsfFlux_flag` used to detect failed PSF photometry.