### PR TITLE
Adds a command line tool to process DM patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # medsdm
 
 Code to create MEDS files from a LSST dmstack interface
+
+## Example
+
+The following command will process a particular tract, patch of DC2 run 1.1p:
+```
+$ python -m medsdm.maker --config test/config_DC2.yaml /global/projecta/projectdirs/lsst/global/in2p3/Run1.1/output 4638 0,0 i
+```

--- a/medsdm/defaults.py
+++ b/medsdm/defaults.py
@@ -31,6 +31,7 @@ DEFAULT_MAKER_CONFIG = {
 # Camera options are: LSST, HSC
 DEFAULT_PRODUCER_CONFIG = {
     'camera':'LSST',
+    'all_filters': ("g", "r", "i", "z", "y"),
     'fake_seg_radius':5,
     'min_box_size':32,
     'max_box_size':256,

--- a/medsdm/maker.py
+++ b/medsdm/maker.py
@@ -550,9 +550,9 @@ if __name__=="__main__":
                             tract=args.tract,
                             patch=args.patch,
                             filter=args.filter,
-                            config= args.config['producer'] if args.config is not None else None)
+                            config=config_producer)
 
     # Create maker instance, with default configuration for now
     maker = DMMedsMaker(producer,
-                        config= args.config['maker'] if args.config is not None else None)
+                        config=config_maker)
     maker.write(fname)

--- a/medsdm/maker.py
+++ b/medsdm/maker.py
@@ -532,7 +532,7 @@ if __name__=="__main__":
     args = parser.parse_args(sys.argv[1:])
 
     # Extracts output filename
-    fname=args.prefix+'-%s-tract%06d-patch%s' % (args.filter, args.tract,
+    fname=args.prefix+'-%s-tract%06d-patch%s.fits' % (args.filter, args.tract,
                         args.patch.replace(',',''))
 
     # Extracts configuration if different from default

--- a/medsdm/maker.py
+++ b/medsdm/maker.py
@@ -542,9 +542,9 @@ if __name__=="__main__":
                             tract=args.tract,
                             patch=args.patch,
                             filter=args.filter,
-                            config= args.config['producer'] if args.config is not None)
+                            config= args.config['producer'] if args.config is not None else None)
 
     # Create maker instance, with default configuration for now
     maker = DMMedsMaker(producer,
-                        config= args.config['maker'] if args.config is not None)
+                        config= args.config['maker'] if args.config is not None else None)
     maker.write(fname)

--- a/medsdm/maker.py
+++ b/medsdm/maker.py
@@ -506,6 +506,7 @@ def test(filter="HSC-I",tract=8766, patch="4,4", limit=10):
 
 if __name__=="__main__":
     import sys
+    import yaml
     from argparse import ArgumentParser, RawTextHelpFormatter
     import lsst.daf.persistence as dafPersist
     from .producer import LSSTProducer
@@ -534,7 +535,14 @@ if __name__=="__main__":
     fname=args.prefix+'-%s-tract%06d-patch%s' % (args.filter, args.tract, args.patch)
 
     # Extracts configuration if different from default
-
+    if args.config is not None:
+        with open(args.config, 'r') as ymlfile:
+            config = yaml.load(ymlfile)
+        config_producer = config['producer']
+        config_maker = config['maker']
+    else:
+        config_producer = None
+        config_maker =  None
 
     # Create producer using default configuration
     butler =  dafPersist.Butler(args.repo)

--- a/medsdm/maker.py
+++ b/medsdm/maker.py
@@ -525,11 +525,10 @@ if __name__=="__main__":
     parser.add_argument('patch', type=str,
                      help='patch to process (e.g. 0,1).')
     parser.add_argument('filter', type=str,
-                     help='Filter to process (e.g. i or HSC-I).')
+                     help='Filter to process (e.g. i).')
     args = parser.parse_args(sys.argv[1:])
 
-    fstr=filter[4:4+1].lower()
-    fname=args.prefix+'-%s-tract%06d-patch%s' % (fstr, args.tract, args.patch)
+    fname=args.prefix+'-%s-tract%06d-patch%s' % (args.filter, args.tract, args.patch)
 
     # Create producer using default configuration
     butler =  dafPersist.Butler(args.repo)

--- a/medsdm/maker.py
+++ b/medsdm/maker.py
@@ -505,6 +505,7 @@ def test(filter="HSC-I",tract=8766, patch="4,4", limit=10):
     maker.write(fname)
 
 if __name__=="__main__":
+    import sys
     from argparse import ArgumentParser, RawTextHelpFormatter
     import lsst.daf.persistence as dafPersist
     from .producer import test_make_producer

--- a/medsdm/maker.py
+++ b/medsdm/maker.py
@@ -518,6 +518,8 @@ if __name__=="__main__":
                          formatter_class=RawTextHelpFormatter)
     parser.add_argument('--prefix', type=str, default='./medsdm',
                         help='Output prefix to use for the meds files.')
+    parser.add_argument('--config', type=str, default=None,
+                        help='Yaml configuration file for medsdm')
     parser.add_argument('repo', type=str,
                      help='Filepath to LSST DM Stack Butler repository.')
     parser.add_argument('tract', type=int,
@@ -528,15 +530,21 @@ if __name__=="__main__":
                      help='Filter to process (e.g. i).')
     args = parser.parse_args(sys.argv[1:])
 
+    # Extracts output filename
     fname=args.prefix+'-%s-tract%06d-patch%s' % (args.filter, args.tract, args.patch)
+
+    # Extracts configuration if different from default
+
 
     # Create producer using default configuration
     butler =  dafPersist.Butler(args.repo)
     producer = LSSTProducer(butler,
                             tract=args.tract,
                             patch=args.patch,
-                            filter=args.filter)
+                            filter=args.filter,
+                            config= args.config['producer'] if args.config is not None)
 
     # Create maker instance, with default configuration for now
-    maker = DMMedsMaker(producer)
+    maker = DMMedsMaker(producer,
+                        config= args.config['maker'] if args.config is not None)
     maker.write(fname)

--- a/medsdm/maker.py
+++ b/medsdm/maker.py
@@ -532,7 +532,8 @@ if __name__=="__main__":
     args = parser.parse_args(sys.argv[1:])
 
     # Extracts output filename
-    fname=args.prefix+'-%s-tract%06d-patch%s' % (args.filter, args.tract, args.patch)
+    fname=args.prefix+'-%s-tract%06d-patch%s' % (args.filter, args.tract,
+                        args.patch.replace(',',''))
 
     # Extracts configuration if different from default
     if args.config is not None:

--- a/medsdm/maker.py
+++ b/medsdm/maker.py
@@ -508,7 +508,7 @@ if __name__=="__main__":
     import sys
     from argparse import ArgumentParser, RawTextHelpFormatter
     import lsst.daf.persistence as dafPersist
-    from .producer import test_make_producer
+    from .producer import LSSTProducer
 
     usage = """
     Extracts MEDS file cutouts from the DM coadds and individual visits for a

--- a/medsdm/producer.py
+++ b/medsdm/producer.py
@@ -36,8 +36,7 @@ class LSSTProducer(object):
        we need about that postage stamp.
     """
 
-    def __init__(self, butler, tract, patch, filter, limit=None, config=None,
-                 all_filters=("g", "r", "i", "z", "y")):
+    def __init__(self, butler, tract, patch, filter, limit=None, config=None):
 
         self.setConfig(config)
         self.butler = butler
@@ -65,7 +64,7 @@ class LSSTProducer(object):
         self.forced = [butler.get("deepCoadd_forced_src", tract=tract, patch=patch,
                                   filter=filter_map[b],
                                   flags=afwTable.SOURCE_IO_NO_FOOTPRINTS)
-                       for b in all_filters]
+                       for b in self.config['all_filters']]
         self.coadd = butler.get(
             "deepCoadd_calexp",
             tract=tract,

--- a/medsdm/producer.py
+++ b/medsdm/producer.py
@@ -49,7 +49,7 @@ class LSSTProducer(object):
 
         # Filter map to handle HSC filters
         if self.config['camera'] == 'LSST':
-            filter_map = {b:b for b in all_filters}
+            filter_map = {b:b for b in self.config['all_filters']}
         elif self.config['camera'] == 'HSC':
             filter_map = {'u': 'HSC-U', 'g': 'HSC-G', 'r': 'HSC-R', 'i': 'HSC-I',
                           'z': 'HSC-Z', 'y': 'HSC-Y'}

--- a/test/config_DC2.yaml
+++ b/test/config_DC2.yaml
@@ -6,7 +6,7 @@ maker:
 
 producer:
     camera: LSST
-    all_filters: ['g', 'r', 'i', 'z', 'y']
+    all_filters: ['r', 'i']
     fake_seg_radius: 5
     min_box_size: 32
     max_box_size: 256

--- a/test/config_DC2.yaml
+++ b/test/config_DC2.yaml
@@ -1,0 +1,16 @@
+maker:
+    cutout_types: ['image', 'weight', 'seg', 'bmask']
+    fake_se_seg: True
+    fpack_dims: [10240, 1]
+    variable_psf_box_size: True
+
+producer:
+    camera: LSST
+    all_filters: ['g', 'r', 'i', 'z', 'y']
+    fake_seg_radius: 5
+    min_box_size: 32
+    max_box_size: 256
+    radius_factor: 5.0
+    include_coadd: True
+    include_epochs: True
+    deblend_coadd: False


### PR DESCRIPTION
This PR adds a commandline tool to process (tract, patch, filter) from the DM outputs, accessed through the DM butler. Also includes some filter name mapping to be compatible with HSC DM outputs.

The command line tool is accessed like this:
```
$ python -m medsdm.maker --config test/config_DC2.yaml /global/projecta/projectdirs/lsst/global/in2p3/Run1.1/output 4638 0,0 i
```
I can also include a standalone `medsdm_maker` script if that would be useful.